### PR TITLE
build: sync typebox

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@nordicsemiconductor/asset-tracker-cloud-docs": "33.0.0",
         "@nordicsemiconductor/lwm2m-types": "2.6.1",
-        "@sinclair/typebox": "0.31.20"
+        "@sinclair/typebox": "0.31.18"
       },
       "devDependencies": {
         "@commitlint/config-conventional": "18.1.0",
@@ -1024,11 +1024,6 @@
         "npm": ">=9"
       }
     },
-    "node_modules/@nordicsemiconductor/asset-tracker-cloud-docs/node_modules/@sinclair/typebox": {
-      "version": "0.31.18",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.31.18.tgz",
-      "integrity": "sha512-p2JGz+SciGJVl1zokCIK15f7LYDrI2ZsxItcLhkAyx50hEYEj/Qdy7z30qRYiakzdIu8dV4DfBi+e6xEZuugiQ=="
-    },
     "node_modules/@nordicsemiconductor/eslint-config-asset-tracker-cloud-typescript": {
       "version": "16.0.23",
       "resolved": "https://registry.npmjs.org/@nordicsemiconductor/eslint-config-asset-tracker-cloud-typescript/-/eslint-config-asset-tracker-cloud-typescript-16.0.23.tgz",
@@ -1052,9 +1047,9 @@
       }
     },
     "node_modules/@sinclair/typebox": {
-      "version": "0.31.20",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.31.20.tgz",
-      "integrity": "sha512-pqkf2X6fc1yk6c3Rk41cT8NYFKmzngl8TVHy375X7ihlONCsX7/YTReRLyZX7zZhuUUBx9KTZPFFDZo6AIERCw=="
+      "version": "0.31.18",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.31.18.tgz",
+      "integrity": "sha512-p2JGz+SciGJVl1zokCIK15f7LYDrI2ZsxItcLhkAyx50hEYEj/Qdy7z30qRYiakzdIu8dV4DfBi+e6xEZuugiQ=="
     },
     "node_modules/@sindresorhus/is": {
       "version": "4.6.0",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   "dependencies": {
     "@nordicsemiconductor/asset-tracker-cloud-docs": "33.0.0",
     "@nordicsemiconductor/lwm2m-types": "2.6.1",
-    "@sinclair/typebox": "0.31.20"
+    "@sinclair/typebox": "0.31.18"
   },
   "devDependencies": {
     "@commitlint/config-conventional": "18.1.0",


### PR DESCRIPTION
Sync typebox version between this repo and @nordicsemiconductor/asset-tracker-cloud-docs@33.0.0 lib