### PR TITLE
fix: assign output result for each object

### DIFF
--- a/src/utils/unwrapResult.spec.ts
+++ b/src/utils/unwrapResult.spec.ts
@@ -1,0 +1,21 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert'
+import { unwrapResult } from './unwrapResult.js'
+import { ValidationError } from './ValidationError.js'
+
+void describe('unwrapResult', () => {
+	void it(`should return the result when the input is known as valid`, (context) => {
+		const onError = context.mock.fn()
+		const result = unwrapResult(onError)({ result: true })
+		assert.deepEqual(result, true)
+	})
+
+	void it(`should return undefined and call the onError callback when the input is known as invalid`, (context) => {
+		const onError = context.mock.fn()
+		const result = unwrapResult(onError)({
+			error: new ValidationError('' as any),
+		})
+		assert.deepEqual(result, undefined)
+		assert.strictEqual(onError.mock.callCount(), 1)
+	})
+})

--- a/src/utils/unwrapResult.spec.ts
+++ b/src/utils/unwrapResult.spec.ts
@@ -8,6 +8,7 @@ void describe('unwrapResult', () => {
 		const onError = context.mock.fn()
 		const result = unwrapResult(onError)({ result: true })
 		assert.deepEqual(result, true)
+		assert.strictEqual(onError.mock.callCount(), 0)
 	})
 
 	void it(`should return undefined and call the onError callback when the input is known as invalid`, (context) => {

--- a/src/utils/unwrapResult.spec.ts
+++ b/src/utils/unwrapResult.spec.ts
@@ -29,7 +29,6 @@ void describe('unwrapResult', () => {
 		assert.strictEqual(onError.mock.callCount(), 1)
 
 		assert.strictEqual(onError.mock.calls.length, 1)
-		if (onError.mock.calls[0] !== undefined)
-			assert.deepEqual(onError.mock.calls[0].arguments[0], reportedError)
+		assert.deepEqual(onError.mock.calls[0]?.arguments?.[0], reportedError)
 	})
 })

--- a/src/utils/unwrapResult.spec.ts
+++ b/src/utils/unwrapResult.spec.ts
@@ -13,10 +13,23 @@ void describe('unwrapResult', () => {
 
 	void it(`should return undefined and call the onError callback when the input is known as invalid`, (context) => {
 		const onError = context.mock.fn()
+		const reportedError = new ValidationError([
+			{
+				instancePath: '/v',
+				schemaPath: '#/properties/v/required',
+				keyword: 'required',
+				params: { missingProperty: 'ip' },
+				message: "must have required property 'ip'",
+			},
+		])
 		const result = unwrapResult(onError)({
-			error: new ValidationError('' as any),
+			error: reportedError,
 		})
 		assert.deepEqual(result, undefined)
 		assert.strictEqual(onError.mock.callCount(), 1)
+
+		assert.strictEqual(onError.mock.calls.length, 1)
+		if (onError.mock.calls[0] !== undefined)
+			assert.deepEqual(onError.mock.calls[0].arguments[0], reportedError)
 	})
 })

--- a/src/utils/unwrapResult.ts
+++ b/src/utils/unwrapResult.ts
@@ -1,0 +1,24 @@
+import type { UndefinedLwM2MObjectWarning } from './UndefinedLwM2MObjectWarning.js'
+import type { ValidationError } from './ValidationError.js'
+
+/**
+ * Unwrap convertion process result.
+ *
+ * If the result of the convertion process is an error, return undefined and trigger the error.
+ * Otherwise return the result value
+ */
+export const unwrapResult =
+	(
+		onError?: (element: ValidationError | UndefinedLwM2MObjectWarning) => void,
+	) =>
+	<Result>(
+		conversionResult:
+			| { result: Result }
+			| { error: ValidationError | UndefinedLwM2MObjectWarning },
+	): Result | undefined => {
+		if ('error' in conversionResult) {
+			onError?.(conversionResult.error)
+			return undefined
+		}
+		return conversionResult.result
+	}


### PR DESCRIPTION
This change is important to make sure output follows expected format.

With the previous solution, filling output over a loop, is not possible to check if object assigning follows expected format